### PR TITLE
Update numpy and openai versions in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,8 @@ PyJWT==2.8.0
 bcrypt==4.1.2
 Flask-Limiter==3.5.0
 requests==2.32.4
-numpy==2.3.2
+numpy==1.26.4
 python-dotenv==1.1.1
-openai
+openai==1.6.1
 pinecone-client==3.0.0
 tqdm==4.66.1


### PR DESCRIPTION
Downgraded numpy from 2.3.2 to 1.26.4 and pinned openai to version 1.6.1 for improved compatibility and stability.